### PR TITLE
AD compatibility when Omega and Vinf are different types - fixes #19

### DIFF
--- a/src/CCBlade.jl
+++ b/src/CCBlade.jl
@@ -533,6 +533,9 @@ function simple_op(Vinf, Omega, r, rho; pitch=zero(rho), mu=one(rho), asound=one
     Vx = Vinf * cos(precone) 
     Vy = Omega * r * cos(precone)
 
+    # for the case where Omega is of type Dual and Vinf is not
+    Vx, Vy = promote(Vx, Vy) 
+    
     return OperatingPoint(Vx, Vy, rho, pitch, mu, asound)
 
 end


### PR DESCRIPTION
In the `simple_op` method, I added a line to promote the type between `Vx` and `Vy` for the case where `Omega` is a Dual type and `Vinf` is not. Also added a test for this.