### PR TITLE
Bump FLOWMath compat to 0.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
           # https://discourse.julialang.org/t/running-ci-for-julia-1-6-on-github-macos-runners-seems-to-fail/116577/3
           # macOS-latest implies arm64, which isn't available for Julia 1.6, so skip that.
           - os: macOS-latest
-          - julia-version: 1.6
+            julia-version: 1.6
 
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,12 @@ jobs:
         julia-version: ['1.6', '1']
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          # https://discourse.julialang.org/t/running-ci-for-julia-1-6-on-github-macos-runners-seems-to-fail/116577/3
+          # macOS-latest implies arm64, which isn't available for Julia 1.6, so skip that.
+          - os: macOS-latest
+          - julia-version: 1.6
+
 
     steps:
       - uses: actions/checkout@v1.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,10 @@ jobs:
           - os: macOS-latest
             julia-version: 1.6
 
+        include:
+          # macOS-13 appears to be the last x64 macOS.
+          - os: macOS-13
+            julia-version: 1.6
 
     steps:
       - uses: actions/checkout@v1.0.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CCBlade"
 uuid = "e1828068-15df-11e9-03e4-ef195ea46fa4"
 authors = ["Andrew Ning <aning@byu.edu>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 FLOWMath = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-FLOWMath = "0.3"
+FLOWMath = "0.3, 0.4"
 ImplicitAD = "0.3.1"
 julia = "1.6"


### PR DESCRIPTION
CCBlade.jl appears to be compatible with FLOWMath v0.4.0 and v0.4.1 (the tests pass for both). Any reason the compat can't be bumped?