### PR TITLE
Fix #28 by removing `Vector` convenience functions

### DIFF
--- a/src/CCBlade.jl
+++ b/src/CCBlade.jl
@@ -86,10 +86,10 @@ function Section(r, chord, theta, af)
 end
 
 
-# convenience function to access fields within an array of structs
-function Base.getproperty(obj::AbstractVector{<:Section}, sym::Symbol)
-    return getfield.(obj, sym)
-end # This is not always type stable b/c we don't know if the return type will be float or af function.
+# # convenience function to access fields within an array of structs
+# function Base.getproperty(obj::Vector{<:Section}, sym::Symbol)
+#     return getfield.(obj, sym)
+# end # This is not always type stable b/c we don't know if the return type will be float or af function.
 
 """
     OperatingPoint(Vx, Vy, rho; pitch=0.0, mu=1.0, asound=1.0)
@@ -123,10 +123,10 @@ OperatingPoint(Vx, Vy, rho, pitch, mu, asound) = OperatingPoint(promote(Vx, Vy, 
 # convenience constructor when Re and Mach are not used.
 OperatingPoint(Vx, Vy, rho; pitch=zero(rho), mu=one(rho), asound=one(rho)) = OperatingPoint(Vx, Vy, rho, pitch, mu, asound)
 
-# convenience function to access fields within an array of structs
-function Base.getproperty(obj::AbstractVector{<:OperatingPoint}, sym::Symbol)
-    return getfield.(obj, sym)
-end
+# # convenience function to access fields within an array of structs
+# function Base.getproperty(obj::Vector{<:OperatingPoint}, sym::Symbol)
+#     return getfield.(obj, sym)
+# end
 
 
 """
@@ -175,10 +175,10 @@ Outputs(Np, Tp, a, ap, u, v, phi, alpha, W, cl, cd, cn, ct, F, G) = Outputs(prom
 # convenience constructor to initialize
 Outputs() = Outputs(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
-# convenience function to access fields within an array of structs
-function Base.getproperty(obj::AbstractVector{<:Outputs}, sym::Symbol)
-    return getfield.(obj, sym)
-end
+# # convenience function to access fields within an array of structs
+# function Base.getproperty(obj::Vector{<:Outputs}, sym::Symbol)
+#     return getfield.(obj, sym)
+# end
 
 # -------------------------------
 
@@ -643,8 +643,8 @@ function thrusttorque(rotor, sections, outputs::AbstractVector{TO}) where TO
     # add hub/tip for complete integration.  loads go to zero at hub/tip.
     rvec = [s.r for s in sections]
     rfull = [rotor.Rhub; rvec; rotor.Rtip]
-    Npfull = [0.0; outputs.Np; 0.0]
-    Tpfull = [0.0; outputs.Tp; 0.0]
+    Npfull = [0.0; getproperty.(outputs, :Np); 0.0]
+    Tpfull = [0.0; getproperty.(outputs, :Tp); 0.0]
 
     # integrate Thrust and Torque (trapezoidal)
     thrust = Npfull*cos(rotor.precone)


### PR DESCRIPTION
#28 shows that creating `Vector`s of eg `Section`s fails with the latest stable Julia 1.11.2, apparently due to the convenience functions like https://github.com/byuflowlab/CCBlade.jl/blob/b5e95143d086bfa6a5612f90799151430e950cdb/src/CCBlade.jl#L127

This PR removes those functions and fixes up the tests. I tried changing `Base.getproperty(obj::AbstractVector{...}, ...)` to `Base.getproperty(obj::Vector{...}, ...)` but that didn't appear to help.

I know this is a breaking change, sorry. :-(