### PR TITLE
Fix the StructArrays support to unbreak Makie :-(

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CCBlade"
 uuid = "e1828068-15df-11e9-03e4-ef195ea46fa4"
 authors = ["Andrew Ning <aning@byu.edu>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 FLOWMath = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"

--- a/src/CCBlade.jl
+++ b/src/CCBlade.jl
@@ -86,8 +86,8 @@ function Section(r, chord, theta, af)
     return Section(r, chord, theta, af)
 end
 
-function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N,ElType<:Section}
-    return StructArray{ElType}(undef, size(bc))
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{Section{TF,TAF}}) where {N,TF,TAF}
+    return StructArray{Section{TF,TAF}}(undef, size(bc))
 end
 
 """
@@ -122,8 +122,8 @@ OperatingPoint(Vx, Vy, rho, pitch, mu, asound) = OperatingPoint(promote(Vx, Vy, 
 # convenience constructor when Re and Mach are not used.
 OperatingPoint(Vx, Vy, rho; pitch=zero(rho), mu=one(rho), asound=one(rho)) = OperatingPoint(Vx, Vy, rho, pitch, mu, asound)
 
-function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N,ElType<:OperatingPoint}
-    return StructArray{ElType}(undef, size(bc))
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{OperatingPoint{TF}}) where {N,TF}
+    return StructArray{OperatingPoint{TF}}(undef, size(bc))
 end
 
 """
@@ -172,8 +172,8 @@ Outputs(Np, Tp, a, ap, u, v, phi, alpha, W, cl, cd, cn, ct, F, G) = Outputs(prom
 # convenience constructor to initialize
 Outputs() = Outputs(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
-function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N,ElType<:Outputs}
-    return StructArray{ElType}(undef, size(bc))
+function Base.similar(bc::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}, ::Type{Outputs{TF}}) where {N,TF}
+    return StructArray{Outputs{TF}}(undef, size(bc))
 end
 
 # -------------------------------


### PR DESCRIPTION
Turns out my fancy StructArrays.jl idea breaks Makie.jl with crazy errors like this

```
│   exception =
│    MethodError: similar(::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(MakieCore.node_pairs), Tuple{Base.Broadcast.Extruded{Vector{Pair{Symbol, Union{}}}, Tuple{Bool}, Tuple{Int64}}}}, ::Type{Union{}}) is ambiguous.
│    
│    Candidates:
│      similar(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N, ElType<:CCBlade.OperatingPoint}
│        @ CCBlade ~/.julia/packages/CCBlade/PivLg/src/CCBlade.jl:125
│      similar(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N, ElType<:CCBlade.Section}
│        @ CCBlade ~/.julia/packages/CCBlade/PivLg/src/CCBlade.jl:89
│      similar(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N}}, ::Type{ElType}) where {N, ElType<:CCBlade.Outputs}
│        @ CCBlade ~/.julia/packages/CCBlade/PivLg/src/CCBlade.jl:175
│    
│    Possible fix, define
│      similar(::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N}}, ::Type{Union{}}) where N
│    
│    Stacktrace:
│      [1] copy
│        @ ./broadcast.jl:902 [inlined]
│      [2] materialize
│        @ ./broadcast.jl:867 [inlined]
│      [3] MakieCore.Attributes(pairs::Vector{Pair{Symbol, Union{}}})
│        @ MakieCore ~/.julia/packages/MakieCore/EU17Y/src/attributes.jl:31
│      [4] MakieCore.Attributes(pairs::@Kwargs{})
│        @ MakieCore ~/.julia/packages/MakieCore/EU17Y/src/attributes.jl:32
│      [5] Makie.Scene(; viewport::Nothing, events::Makie.Events, clear::Bool, transform_func::Function, camera::typeof(Makie.campixel!), camera_controls::Makie.EmptyCamera, transformation::Makie.Transformation, plots::Vector{MakieCore.AbstractPlot}, children::Vector{Makie.Scene}, 
current_screens::Vector{MakieCore.MakieScreen}, parent::Nothing, visible::Observables.Observable{Bool}, ssao::Makie.SSAO, lights::MakieCore.Automatic, theme::MakieCore.Attributes, deregister_callbacks::Vector{Observables.ObserverFunction}, theme_kw::@Kwargs{})
│        @ Makie ~/.julia/packages/Makie/Y3ABD/src/scenes.jl:231
│      [6] Makie.Figure(; kwargs::@Kwargs{})
│        @ Makie ~/.julia/packages/Makie/Y3ABD/src/figures.jl:112
│      [7] Makie.Figure()
│        @ Makie ~/.julia/packages/Makie/Y3ABD/src/figures.jl:108
│      [8] top-level scope
│        @ sqa.md:431
│      [9] eval
│        @ ./boot.jl:430 [inlined]
│     [10] #61
│        @ ~/.julia/packages/Documenter/tbj1p/src/expander_pipeline.jl:835 [inlined]
│     [11] cd(f::Documenter.var"#61#63"{Module, Expr}, dir::String)
│        @ Base.Filesystem ./file.jl:112
│     [12] (::Documenter.var"#60#62"{Documenter.Page, Module, Expr})()
│        @ Documenter ~/.julia/packages/Documenter/tbj1p/src/expander_pipeline.jl:834
│     [13] (::IOCapture.var"#5#9"{DataType, Documenter.var"#60#62"{Documenter.Page, Module, Expr}, IOContext{Base.PipeEndpoint}, IOContext{Base.PipeEndpoint}, Base.TTY, Base.TTY})()
│        @ IOCapture ~/.julia/packages/IOCapture/Y5rEA/src/IOCapture.jl:170
│     [14] with_logstate(f::IOCapture.var"#5#9"{DataType, Documenter.var"#60#62"{Documenter.Page, Module, Expr}, IOContext{Base.PipeEndpoint}, IOContext{Base.PipeEndpoint}, Base.TTY, Base.TTY}, logstate::Base.CoreLogging.LogState)
│        @ Base.CoreLogging ./logging/logging.jl:522
│     [15] with_logger(f::Function, logger::Base.CoreLogging.ConsoleLogger)
│        @ Base.CoreLogging ./logging/logging.jl:632
│     [16] capture(f::Documenter.var"#60#62"{Documenter.Page, Module, Expr}; rethrow::Type, color::Bool, passthrough::Bool, capture_buffer::IOBuffer, io_context::Vector{Any})
│        @ IOCapture ~/.julia/packages/IOCapture/Y5rEA/src/IOCapture.jl:167
│     [17] runner(::Type{Documenter.Expanders.ExampleBlocks}, node::MarkdownAST.Node{Nothing}, page::Documenter.Page, doc::Documenter.Document)
│        @ Documenter ~/.julia/packages/Documenter/tbj1p/src/expander_pipeline.jl:833
└ @ Documenter ~/.julia/packages/Documenter/tbj1p/src/utilities/utilities.jl:47

```

Luckily it looks like the fix is simple, though I don't understand why it works... :-(